### PR TITLE
Refactor: Photo 로직 분리 & Feat: Interceptor 및 LoginUserArgumentResolver 적용

### DIFF
--- a/app/src/main/java/bitcamp/project/App.java
+++ b/app/src/main/java/bitcamp/project/App.java
@@ -3,16 +3,42 @@
  */
 package bitcamp.project;
 
+import bitcamp.project.annotation.LoginUserArgumentResolver;
+import bitcamp.project.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @SpringBootApplication
 @MapperScan("bitcamp.project.dao")
 @PropertySource("file:${user.home}/config/final.properties")
-public class App {
+@EnableTransactionManagement
+@RequiredArgsConstructor
+public class App implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
+    }
+
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+            .addPathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserArgumentResolver());
     }
 }

--- a/app/src/main/java/bitcamp/project/annotation/LoginUser.java
+++ b/app/src/main/java/bitcamp/project/annotation/LoginUser.java
@@ -1,0 +1,11 @@
+package bitcamp.project.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/app/src/main/java/bitcamp/project/annotation/LoginUserArgumentResolver.java
+++ b/app/src/main/java/bitcamp/project/annotation/LoginUserArgumentResolver.java
@@ -1,0 +1,31 @@
+package bitcamp.project.annotation;
+
+import bitcamp.project.vo.User;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+
+    return parameter.hasParameterAnnotation(LoginUser.class) &&
+        parameter.getParameterType().isAssignableFrom(User.class);
+  }
+
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+    HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+    HttpSession session = request.getSession();
+    return session.getAttribute(parameter.getParameterName());
+  }
+}

--- a/app/src/main/java/bitcamp/project/controller/LikeController.java
+++ b/app/src/main/java/bitcamp/project/controller/LikeController.java
@@ -1,11 +1,10 @@
 package bitcamp.project.controller;
 
+import bitcamp.project.annotation.LoginUser;
 import bitcamp.project.dto.StoryListDTO;
 import bitcamp.project.service.LikeService;
 import bitcamp.project.service.StoryService;
 import bitcamp.project.service.UserService;
-import bitcamp.project.vo.Like;
-import bitcamp.project.vo.Story;
 import bitcamp.project.vo.User;
 import lombok.RequiredArgsConstructor;
 
@@ -29,12 +28,10 @@ public class LikeController {
 
   // 나를 좋아요한 User 목록 (미확인만)
   // 확인 방법 : confirmView()
-  @GetMapping("list")
-  public ResponseEntity<?> findAllToMe(@RequestHeader("Authorization") String token) {
+  @GetMapping("list/users")
+  public ResponseEntity<?> findAllToMe(@LoginUser User loginUser) {
     try {
-      User user = userService.decodeToken(token);
-      System.out.println(user.getId());
-      List<User> users = likeService.findAllToMe(user.getId());
+      List<User> users = likeService.findAllToMe(loginUser.getId());
       return ResponseEntity.ok(users);
 
     } catch (Exception e) {
@@ -44,10 +41,10 @@ public class LikeController {
 
 
   // 내가 좋아요한 스토리 목록
-  @GetMapping("list/user/{userId}")
-  public ResponseEntity<?> findAllByMyLike(@PathVariable int userId) {
+  @GetMapping("list/my-stories")
+  public ResponseEntity<?> listAllMyLikeStories(@LoginUser User loginUser) {
     try {
-      List<StoryListDTO> storyListDTOs = storyService.listAllMyLikeStories(userId);
+      List<StoryListDTO> storyListDTOs = storyService.listAllMyLikeStories(loginUser.getId());
       return ResponseEntity.ok(storyListDTOs);
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("내가 좋아요한 스토리 목록을 불러오는 데 실패했습니다.");
@@ -56,11 +53,11 @@ public class LikeController {
 
 
   // 좋아요 등록
-  @GetMapping("add/{storyId}/{userId}")
+  @GetMapping("add/{storyId}")
   public ResponseEntity<String> add(
-      @PathVariable int storyId, @PathVariable int userId) {
+      @PathVariable int storyId, @LoginUser User loginUser) {
     try {
-      likeService.addLike(storyId, userId);
+      likeService.addLike(storyId, loginUser.getId());
       return ResponseEntity.ok("좋아요 등록 완료!");
 
     } catch (Exception e) {
@@ -69,11 +66,11 @@ public class LikeController {
   }
 
   // 좋아요 취소
-  @DeleteMapping("delete/{storyId}/{userId}")
+  @DeleteMapping("delete/{storyId}")
   public ResponseEntity<String> delete(
-      @PathVariable int storyId, @PathVariable int userId) {
+      @PathVariable int storyId, @LoginUser User loginUser) {
     try {
-      likeService.deleteLike(storyId, userId);
+      likeService.deleteLike(storyId, loginUser.getId());
       return ResponseEntity.ok("좋아요 삭제 완료!");
 
     } catch (Exception e) {
@@ -83,12 +80,12 @@ public class LikeController {
 
 
   // 스토리 알림 확인 시 목록에서 제거
-  @GetMapping("confirm/{storyId}/{otherUserId}/{loginUserId}")
+  @GetMapping("confirm/{storyId}/{otherUserId}")
   public ResponseEntity<String> confirmView(
       @PathVariable int storyId, @PathVariable int otherUserId,
-      @PathVariable int loginUserId) {
+      @LoginUser User loginUser) {
     try {
-      likeService.confirmLikeView(storyId, otherUserId, loginUserId);
+      likeService.confirmLikeView(storyId, otherUserId, loginUser.getId());
       return ResponseEntity.ok("알림 확인 완료!");
 
     } catch (Exception e) {

--- a/app/src/main/java/bitcamp/project/controller/LocationController.java
+++ b/app/src/main/java/bitcamp/project/controller/LocationController.java
@@ -1,8 +1,11 @@
 package bitcamp.project.controller;
 
+import bitcamp.project.dto.StoryViewDTO;
 import bitcamp.project.service.LocationService;
 import bitcamp.project.vo.Location;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,13 +21,26 @@ public class LocationController {
   private final LocationService locationService;
 
   @GetMapping("list")
-  public List<String> getFirstNames() throws Exception {
-    return locationService.getFirstNames();
+  public ResponseEntity<?> getFirstNames() throws Exception {
+    try {
+      List<String> list = locationService.getFirstNames();
+      return ResponseEntity.ok(list);
+
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    }
   }
 
+
   @GetMapping("list/{firstName}")
-  public List<Location> getSecondNames(@PathVariable String firstName) throws Exception {
-    return locationService.getSecondNames(firstName);
+  public ResponseEntity<?> getSecondNames(@PathVariable String firstName) throws Exception {
+    try {
+      List<Location> list = locationService.getSecondNames(firstName);
+      return ResponseEntity.ok(list);
+
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    }
   }
 
 }

--- a/app/src/main/java/bitcamp/project/controller/MyStoryController.java
+++ b/app/src/main/java/bitcamp/project/controller/MyStoryController.java
@@ -1,5 +1,6 @@
 package bitcamp.project.controller;
 
+import bitcamp.project.annotation.LoginUser;
 import bitcamp.project.dto.AddStoryRequestDTO;
 import bitcamp.project.dto.StoryListDTO;
 import bitcamp.project.dto.StoryViewDTO;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpSession;
 import java.util.*;
 
 @RestController
@@ -24,28 +26,26 @@ public class MyStoryController {
 
     private final StoryService storyService;
 
-    @GetMapping("list/{userId}")
-    public ResponseEntity<?> list(@PathVariable int userId) {
+    @GetMapping("list")
+    public ResponseEntity<?> list(@LoginUser User loginUser) {
         try {
-            List<StoryListDTO> storyListDTOs = storyService.listAllMyStories(userId);
+            List<StoryListDTO> storyListDTOs = storyService.listAllMyStories(loginUser.getId());
             return ResponseEntity.ok(storyListDTOs);
 
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("내 스토리 목록 가져오기 실패");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
 
 
-    @GetMapping("view/{storyId}/{userId}")
-    public ResponseEntity<?> view(
-        @PathVariable int storyId,
-        @RequestParam int userId) {
+    @GetMapping("view/{storyId}")
+    public ResponseEntity<?> view(@PathVariable int storyId, @LoginUser User loginUser) {
         try {
-            StoryViewDTO storyViewDTO = storyService.viewMyStory(storyId, userId);
+            StoryViewDTO storyViewDTO = storyService.viewMyStory(storyId, loginUser.getId());
             return ResponseEntity.ok(storyViewDTO);
 
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("내 스토리 상세 조회 실패");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
 
@@ -54,41 +54,34 @@ public class MyStoryController {
     public void formAdd() {
     }
 
-    @GetMapping("form/update/{storyId}/{userId}")
-    public ResponseEntity<?> formUpdate(
-        @PathVariable int storyId, @PathVariable int userId) throws Exception {
+
+    @GetMapping("form/update/{storyId}")
+    public ResponseEntity<?> formUpdate(@PathVariable int storyId, @LoginUser User loginUser) {
         try {
-            StoryViewDTO storyViewDTO = storyService.viewMyStory(storyId, userId);
+            StoryViewDTO storyViewDTO = storyService.viewMyStory(storyId, loginUser.getId());
             return ResponseEntity.ok(storyViewDTO);
-
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("내 스토리 상세 조회 실패");
-        }
-    }
-
-
-    @DeleteMapping("delete/{storyId}/{userId}")
-    public ResponseEntity<String> delete(
-        @PathVariable int storyId, @PathVariable int userId) throws Exception {
-        try {
-            storyService.delete(storyId, userId);
-            return ResponseEntity.ok("스토리 제거가 성공하였습니다.");
 
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
 
+
     @PostMapping("add")
     public ResponseEntity<?> add (
         @ModelAttribute AddStoryRequestDTO addStoryRequestDTO,
-        MultipartFile[] files) {
-        try {  // API 요청 테스트로 인한 return
+        MultipartFile[] files,
+        @LoginUser User loginUser) {
+        try {
+            // 로그인 사용자를 설정
+            addStoryRequestDTO.setLoginUser(loginUser);
+
+            // API 요청 테스트로 인한 return
             ResponseEntity<Map<String, Object>> response = storyService.add(addStoryRequestDTO, files);
             return ResponseEntity.ok(response);
 
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("스토리 추가에 실패했습니다.");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
 
@@ -96,23 +89,40 @@ public class MyStoryController {
     @PostMapping("update")
     public ResponseEntity<?> update(
         @ModelAttribute UpdateStoryRequestDTO updateStoryRequestDTO,
-        MultipartFile[] files) {
-        try {  // API 요청 테스트로 인한 return
+        MultipartFile[] files,
+        @LoginUser User loginUser) {
+        try {
+            // 로그인 사용자를 설정
+            updateStoryRequestDTO.setLoginUser(loginUser);
+
+            // API 요청 테스트로 인한 return
             ResponseEntity<Map<String, Object>> response = storyService.update(updateStoryRequestDTO, files);
             return ResponseEntity.ok(response);
 
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("스토리 수정에 실패했습니다.");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
 
 
-
-    @DeleteMapping("photo/delete/{photoId}/{userId}")
-    public ResponseEntity<String> deletePhoto(
-        @PathVariable int photoId, @PathVariable int userId) throws Exception {
+    @DeleteMapping("delete/{storyId}")
+    public ResponseEntity<String> delete(
+        @PathVariable int storyId, @LoginUser User loginUser) {
         try {
-            storyService.deletePhoto(photoId, userId);
+            storyService.delete(storyId, loginUser.getId());
+            return ResponseEntity.ok("스토리 제거가 성공하였습니다.");
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+
+
+    @DeleteMapping("photo/delete/{photoId}")
+    public ResponseEntity<String> deletePhoto(
+        @PathVariable int photoId, @LoginUser User loginUser) {
+        try {
+            storyService.removePhoto(photoId, loginUser.getId());
             return ResponseEntity.ok("첨부사진 제거가 성공하였습니다.");
 
         } catch (Exception e) {

--- a/app/src/main/java/bitcamp/project/controller/ShareStoryController.java
+++ b/app/src/main/java/bitcamp/project/controller/ShareStoryController.java
@@ -1,9 +1,13 @@
 package bitcamp.project.controller;
 
+import bitcamp.project.annotation.LoginUser;
 import bitcamp.project.dto.StoryListDTO;
 import bitcamp.project.dto.StoryViewDTO;
 import bitcamp.project.service.StoryService;
+import bitcamp.project.vo.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,15 +23,27 @@ public class ShareStoryController {
 
     private final StoryService storyService;
 
-    @GetMapping("list/{userId}")
-    public List<StoryListDTO> list(@PathVariable int userId) throws Exception {
-        return storyService.listAllShareStories(userId);
+    @GetMapping("list")
+    public ResponseEntity<?> list(@LoginUser User loginUser) throws Exception {
+        try {
+            List<StoryListDTO> storyListDTOs = storyService.listAllShareStories(loginUser.getId());
+            return ResponseEntity.ok(storyListDTOs);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
 
     @GetMapping("view/{storyId}")
-    public StoryViewDTO view(@PathVariable  int storyId) throws Exception {
-        return storyService.viewShareStory(storyId);
+    public ResponseEntity<?> view(@PathVariable  int storyId) throws Exception {
+        try {
+            StoryViewDTO storyViewDTO = storyService.viewShareStory(storyId);
+            return ResponseEntity.ok(storyViewDTO);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }
 

--- a/app/src/main/java/bitcamp/project/controller/StoryController.java
+++ b/app/src/main/java/bitcamp/project/controller/StoryController.java
@@ -1,9 +1,12 @@
 package bitcamp.project.controller;
 
+import bitcamp.project.annotation.LoginUser;
 import bitcamp.project.service.*;
 import bitcamp.project.vo.*;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -15,19 +18,14 @@ public class StoryController {
     private final StoryService storyService;
 
     @GetMapping("share/{storyId}")
-    public Story share(@PathVariable int storyId, @RequestParam int userId) throws Exception {
-        Story story = storyService.get(storyId);
-        if (story == null) {
-            throw new Exception("스토리 정보 없음");
-        }
+    public ResponseEntity<?> share(@PathVariable int storyId, @LoginUser User loginUser) {
+        try {
+            Story story = storyService.changeShare(storyId, loginUser.getId());
+            return ResponseEntity.ok(story);
 
-        if (story.getUser().getId() != userId) {
-            throw new Exception("접근 권한이 없습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
-
-        story.setShare(!story.isShare());
-        // storyService.update(story);
-        return story;
     }
 
 }

--- a/app/src/main/java/bitcamp/project/dao/LikeDao.java
+++ b/app/src/main/java/bitcamp/project/dao/LikeDao.java
@@ -22,5 +22,7 @@ public interface LikeDao {
 
   boolean delete(@Param("storyId") int storyId, @Param("userId") int userId) throws Exception;
 
+  boolean deleteAllByStory(int storyId) throws Exception;
+
   int getStatus(@Param("storyId") int storyId, @Param("userId") int userId) throws Exception;
 }

--- a/app/src/main/java/bitcamp/project/dao/PhotoDao.java
+++ b/app/src/main/java/bitcamp/project/dao/PhotoDao.java
@@ -1,0 +1,21 @@
+package bitcamp.project.dao;
+
+import bitcamp.project.vo.Photo;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface PhotoDao {
+
+  boolean insertPhoto(Photo photo) throws Exception;
+
+  Photo getPhoto(int photoId) throws Exception;
+
+  List<Photo> getPhotos(int storyId) throws Exception;
+
+  boolean deletePhoto(int photoId) throws Exception;
+
+  boolean deletePhotos(int storyId) throws Exception;
+
+}

--- a/app/src/main/java/bitcamp/project/dao/StoryDao.java
+++ b/app/src/main/java/bitcamp/project/dao/StoryDao.java
@@ -23,15 +23,4 @@ public interface StoryDao {
 
     boolean delete(int storyId) throws Exception;
 
-    boolean deleteLikes(int storyId) throws Exception;
-
-    boolean deletePhotos(int storyId) throws Exception;
-
-    Photo getPhoto(int photoId) throws Exception;
-
-    List<Photo> getPhotos(int storyId) throws Exception;
-
-    boolean deletePhoto(int photoId) throws Exception;
-
-    boolean insertPhoto(Photo photo) throws Exception;
 }

--- a/app/src/main/java/bitcamp/project/dto/AddStoryRequestDTO.java
+++ b/app/src/main/java/bitcamp/project/dto/AddStoryRequestDTO.java
@@ -20,11 +20,11 @@ public class AddStoryRequestDTO {
   private boolean share;
   private String firstName;
   private String secondName;
-  private int userId;
+  private User loginUser;
 
 
   // VO로 변환하는 메서드
-  public Story toStory(User user, Location location) {
+  public Story toStory(Location location) {
 
     Story story = new Story();
     story.setTitle(title);
@@ -32,8 +32,8 @@ public class AddStoryRequestDTO {
     story.setLocationDetail(locationDetail);
     story.setContent(content);
     story.setShare(share);
+    story.setUser(loginUser);
 
-    story.setUser(user);
     story.setLocation(location);
 
     return story;

--- a/app/src/main/java/bitcamp/project/dto/UpdateStoryRequestDTO.java
+++ b/app/src/main/java/bitcamp/project/dto/UpdateStoryRequestDTO.java
@@ -20,10 +20,11 @@ public class UpdateStoryRequestDTO {
   private String firstName;
   private String secondName;
   private int oldStoryId;
-  private int userId;
+  private User loginUser;
+
 
   // VO로 변환하는 메서드
-  public Story toStory(User user, Location location) {
+  public Story toStory(Location location) {
 
     Story story = new Story();
     story.setTitle(title);
@@ -31,8 +32,8 @@ public class UpdateStoryRequestDTO {
     story.setLocationDetail(locationDetail);
     story.setContent(content);
     story.setShare(share);
+    story.setUser(loginUser);
 
-    story.setUser(user);
     story.setLocation(location);
 
     return story;

--- a/app/src/main/java/bitcamp/project/interceptor/AuthInterceptor.java
+++ b/app/src/main/java/bitcamp/project/interceptor/AuthInterceptor.java
@@ -1,0 +1,47 @@
+package bitcamp.project.interceptor;
+
+import bitcamp.project.service.UserService;
+import bitcamp.project.vo.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+  private final UserService userService;
+
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+
+    String token = request.getHeader("Authorization");
+
+    // 인증이 필요 없는 경로를 설정
+    String requestURI = request.getRequestURI();
+    if (requestURI.startsWith("/sign") || requestURI.startsWith("/faqs")) {
+      return true;
+    }
+
+
+    if (token != null && !token.isEmpty()) {
+      User loginUser = userService.decodeToken(token);
+      HttpSession session = request.getSession();
+      session.setAttribute("loginUser", loginUser); // userId 저장
+
+    } else {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다.");
+      return false;
+    }
+
+    return true;
+  }
+
+}

--- a/app/src/main/java/bitcamp/project/service/LikeService.java
+++ b/app/src/main/java/bitcamp/project/service/LikeService.java
@@ -11,8 +11,6 @@ public interface LikeService {
 
   Like get(int storyId, int userId) throws Exception;
 
-  List<Like> findAllByStory(int storyId) throws Exception;
-
   List<User> findAllToMe(int userId) throws Exception;
 
   int countLikes(int storyId) throws Exception;
@@ -22,4 +20,6 @@ public interface LikeService {
   void confirmLikeView(int storyId, int userId, int loginUserId) throws Exception;
 
   void deleteLike(int storyId, int userId) throws Exception;
+
+  void deleteLikes(int storyId) throws Exception;
 }

--- a/app/src/main/java/bitcamp/project/service/PhotoService.java
+++ b/app/src/main/java/bitcamp/project/service/PhotoService.java
@@ -6,11 +6,13 @@ import java.util.List;
 
 public interface PhotoService {
 
+  void addPhotos(List<Photo> photos) throws Exception;
+
   List<Photo> getPhotosByStoryId(int storyId) throws Exception;
 
   Photo getPhoto(int photoId) throws Exception;
 
-  void addPhotos(List<Photo> photos) throws Exception;
-
   void deletePhoto(int photoId) throws Exception;
+
+  void deletePhotos(int storyId) throws Exception;
 }

--- a/app/src/main/java/bitcamp/project/service/StoryService.java
+++ b/app/src/main/java/bitcamp/project/service/StoryService.java
@@ -17,15 +17,11 @@ public interface StoryService {
 
     ResponseEntity<Map<String, Object>> add(AddStoryRequestDTO addStoryRequestDTO, MultipartFile[] files) throws Exception;
 
-    List<Story> list() throws Exception;
-
-    Story get(int id) throws Exception;
-
     ResponseEntity<Map<String, Object>> update(UpdateStoryRequestDTO updateStoryRequestDTO, MultipartFile[] files) throws Exception;
 
     void delete(int storyId, int userId) throws Exception;
 
-    void deletePhoto(int photoId, int userId) throws Exception;
+    void removePhoto(int photoId, int userId) throws Exception;
 
     List<StoryListDTO> listAllShareStories(int userId) throws Exception;
 
@@ -36,4 +32,6 @@ public interface StoryService {
     StoryViewDTO viewMyStory(int storyId, int userId) throws Exception;
 
     List<StoryListDTO> listAllMyLikeStories(int userId) throws Exception;
+
+    Story changeShare(int storyId, int userId) throws Exception;
 }

--- a/app/src/main/java/bitcamp/project/service/impl/LikeServiceImpl.java
+++ b/app/src/main/java/bitcamp/project/service/impl/LikeServiceImpl.java
@@ -20,6 +20,7 @@ public class LikeServiceImpl implements LikeService {
   private final LikeDao likeDao;
   private final StoryDao storyDao;
 
+
   @Override
   public void addLike(int storyId, int userId) throws Exception {
     Story story = storyDao.findByStoryId(storyId);
@@ -30,30 +31,30 @@ public class LikeServiceImpl implements LikeService {
     likeDao.insert(storyId, userId);
   }
 
+
   @Override
   public Like get(int storyId, int userId) throws Exception {
     return likeDao.findBy(storyId, userId);
   }
 
-  @Override
-  public List<Like> findAllByStory(int storyId) throws Exception {
-    return likeDao.findAllByStory(storyId);
-  }
 
   @Override
   public List<User> findAllToMe(int userId) throws Exception {
     return likeDao.findAllToMe(userId);
   }
 
+
   @Override
   public int countLikes(int storyId) throws Exception {
     return likeDao.findAllByStory(storyId).size();
   }
 
+
   @Override
   public boolean getStatus(int storyId, int userId) throws Exception {
     return likeDao.getStatus(storyId, userId) > 0;
   }
+
 
   @Override
   public void confirmLikeView(int storyId, int otherUserId, int loginUserId) throws Exception {
@@ -74,6 +75,7 @@ public class LikeServiceImpl implements LikeService {
     likeDao.update(like);
   }
 
+
   @Override
   public void deleteLike(int storyId, int userId) throws Exception {
 
@@ -89,4 +91,13 @@ public class LikeServiceImpl implements LikeService {
 
     likeDao.delete(storyId, userId);
   }
+
+
+  @Override
+  public void deleteLikes(int storyId) throws Exception {
+    likeDao.deleteAllByStory(storyId);
+  }
+
+
+
 }

--- a/app/src/main/java/bitcamp/project/service/impl/PhotoServiceImpl.java
+++ b/app/src/main/java/bitcamp/project/service/impl/PhotoServiceImpl.java
@@ -1,6 +1,6 @@
 package bitcamp.project.service.impl;
 
-import bitcamp.project.dao.StoryDao;
+import bitcamp.project.dao.PhotoDao;
 import bitcamp.project.service.PhotoService;
 import bitcamp.project.vo.Photo;
 import lombok.RequiredArgsConstructor;
@@ -13,32 +13,39 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PhotoServiceImpl implements PhotoService {
 
-  private final StoryDao storyDao;
-
-  @Override
-  public List<Photo> getPhotosByStoryId(int storyId) throws Exception {
-    return storyDao.getPhotos(storyId);
-  }
-
-
-  @Override
-  public Photo getPhoto(int photoId) throws Exception {
-    return storyDao.getPhoto(photoId);
-  }
+  private final PhotoDao photoDao;
 
 
   @Transactional
   @Override
   public void addPhotos(List<Photo> photos) throws Exception {
     for (Photo photo : photos) {
-      storyDao.insertPhoto(photo);
+      photoDao.insertPhoto(photo);
     }
   }
 
 
   @Override
+  public List<Photo> getPhotosByStoryId(int storyId) throws Exception {
+    return photoDao.getPhotos(storyId);
+  }
+
+
+  @Override
+  public Photo getPhoto(int photoId) throws Exception {
+    return photoDao.getPhoto(photoId);
+  }
+
+
+  @Override
   public void deletePhoto(int photoId) throws Exception {
-    storyDao.deletePhoto(photoId);
+    photoDao.deletePhoto(photoId);
+  }
+
+
+  @Override
+  public void deletePhotos(int storyId) throws Exception {
+    photoDao.deletePhotos(storyId);
   }
 
 

--- a/app/src/main/resources/bitcamp/project/dao/LikeDao.xml
+++ b/app/src/main/resources/bitcamp/project/dao/LikeDao.xml
@@ -20,6 +20,19 @@
     </resultMap>
 
 
+
+    <insert id="insert">
+        INSERT INTO story_like(user_id, story_id)
+        VALUES (#{userId}, #{storyId})
+    </insert>
+
+
+    <select id="findBy" resultMap="LikeMap">
+        SELECT * FROM story_like
+        WHERE story_id = #{storyId} AND user_id = #{userId}
+    </select>
+
+
     <select id="findAllByStory" resultMap="LikeMap" parameterType="int">
         SELECT * FROM story_like WHERE story_id = #{storyId}
     </select>
@@ -40,27 +53,27 @@
             l.like_date desc
     </select>
 
-    <select id="findBy" resultMap="LikeMap">
-        SELECT * FROM story_like
-        WHERE story_id = #{storyId} AND user_id = #{userId}
-    </select>
-
-    <select id="getStatus" resultType="int">
-        SELECT COUNT(*) FROM story_like WHERE story_id = #{storyId} AND user_id = #{userId}
-    </select>
-
-    <insert id="insert">
-        INSERT INTO story_like(user_id, story_id)
-        VALUES (#{userId}, #{storyId})
-    </insert>
 
     <update id="update" parameterType="like">
         UPDATE story_like SET view=#{view}
         WHERE story_id=#{storyId} AND user_id=#{userId}
     </update>
 
+
     <delete id="delete">
         DELETE FROM story_like WHERE story_id=#{storyId} AND user_id=#{userId}
     </delete>
+
+
+    <delete id="deleteAllByStory" parameterType="int">
+        delete from story_like
+        where story_id = #{storyId}
+    </delete>
+
+
+    <select id="getStatus" resultType="int">
+        SELECT COUNT(*) FROM story_like WHERE story_id = #{storyId} AND user_id = #{userId}
+    </select>
+
 
 </mapper>

--- a/app/src/main/resources/bitcamp/project/dao/PhotoDao.xml
+++ b/app/src/main/resources/bitcamp/project/dao/PhotoDao.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="bitcamp.project.dao.PhotoDao">
+
+    <resultMap id="PhotoMap" type="photo">
+        <id column="photo_id" property="id"/>
+        <result column="story_id" property="storyId"/>
+        <result column="main_photo" property="mainPhoto"/>
+        <result column="path" property="path"/>
+    </resultMap>
+
+
+
+    <insert id="insertPhoto" parameterType="photo"
+            useGeneratedKeys="true" keyColumn="photo_id" keyProperty="id">
+        INSERT INTO story_photo(story_id, main_photo, path)
+        VALUES (#{storyId}, #{mainPhoto}, #{path})
+    </insert>
+
+
+    <select id="getPhoto" resultMap="PhotoMap">
+        SELECT *
+        FROM
+            story_photo
+        WHERE
+            photo_id = #{id}
+    </select>
+
+
+    <select id="getPhotos" resultMap="PhotoMap">
+        SELECT *
+        FROM
+            story_photo
+        WHERE
+            story_id=#{storyId}
+    </select>
+
+
+    <delete id="deletePhoto" parameterType="int">
+        delete from story_photo
+        where photo_id = #{id}
+    </delete>
+
+
+    <delete id="deletePhotos" parameterType="int">
+        delete from story_photo
+        where story_id = #{storyId}
+    </delete>
+
+
+</mapper>

--- a/app/src/main/resources/bitcamp/project/dao/StoryDao.xml
+++ b/app/src/main/resources/bitcamp/project/dao/StoryDao.xml
@@ -28,19 +28,13 @@
         </association>
     </resultMap>
 
-    <resultMap id="PhotoMap" type="photo">
-        <id column="photo_id" property="id"/>
-        <result column="story_id" property="storyId"/>
-        <result column="main_photo" property="mainPhoto"/>
-        <result column="path" property="path"/>
-    </resultMap>
 
-    <resultMap id="LikeMap" type="like">
-        <id column="user_id" property="userId"/>
-        <id column="story_id" property="storyId"/>
-        <result column="like_date" property="likeDate"/>
-        <result column="view" property="view"/>
-    </resultMap>
+    <insert id="insert" parameterType="story"
+            useGeneratedKeys="true" keyColumn="story_id" keyProperty="id">
+        INSERT INTO story(user_id, location_id, title, travel_date, location_detail, content, share)
+        VALUES (#{user.id}, #{location.id}, #{title}, #{travelDate}, #{locationDetail}, #{content}, #{share})
+    </insert>
+
 
     <select id="findAll" resultMap="StoryMap">
         SELECT
@@ -92,6 +86,7 @@
         ORDER BY
             s.story_id desc
     </select>
+
 
     <select id="findAllByMyLike" resultMap="StoryMap" parameterType="int">
         SELECT
@@ -145,11 +140,6 @@
             story_id = #{id}
     </select>
 
-    <insert id="insert" parameterType="story"
-            useGeneratedKeys="true" keyColumn="story_id" keyProperty="id">
-        INSERT INTO story(user_id, location_id, title, travel_date, location_detail, content, share)
-        VALUES (#{user.id}, #{location.id}, #{title}, #{travelDate}, #{locationDetail}, #{content}, #{share})
-    </insert>
 
     <update id="update" parameterType="story">
         update story set
@@ -162,42 +152,10 @@
         where story_id=#{id}
     </update>
 
+
     <delete id="delete" parameterType="int">
         DELETE FROM story WHERE story_id=#{id}
     </delete>
 
-    <delete id="deleteLikes" parameterType="int">
-        delete from story_like
-        where story_id = #{id}
-    </delete>
-
-    <delete id="deletePhotos" parameterType="int">
-        delete from story_photo
-        where story_id = #{id}
-    </delete>
-
-    <insert id="insertPhoto" parameterType="photo"
-            useGeneratedKeys="true" keyColumn="photo_id" keyProperty="id">
-        INSERT INTO story_photo(story_id, main_photo, path)
-        VALUES (#{storyId}, #{mainPhoto}, #{path})
-    </insert>
-
-    <select id="getPhoto" resultMap="PhotoMap">
-        SELECT * FROM story_photo
-        WHERE photo_id = #{id}
-    </select>
-
-    <delete id="deletePhoto" parameterType="int">
-        delete from story_photo
-        where photo_id = #{id}
-    </delete>
-
-    <select id="getPhotos" resultMap="PhotoMap">
-        SELECT *
-        FROM
-            story_photo
-        WHERE
-            story_id=#{id}
-    </select>
 
 </mapper>


### PR DESCRIPTION
리펙토링
1. PhotoDao.java 및 PhotoDao.xml 생성
=>  너무 비대해진 StoryService에서 Photo 관련 부분을 
PhotoService로 분리한 것에 따른 DAO 분리

2. StoryDao에서 
insertPhoto(), getPhoto(), getPhotos(), deletePhoto(), deletePhotos()를
PhotoDao로 이동 및 deletePhotos() 생성

3. StoryDao에서 deleteLikes()를 LikeDao로 이동 (deleteAllByStory()로 이름 변경)
=>  Like 관련 기능은 LikeService에서 처리하도록

4. StoryDao.xml 수정  (LikeMap, PhotoMap 삭제 및 정리) 
=>  Photo 및 Like 관련 사항 삭제

5. 수정 사항 작동 테스트 완료


기능 추가
1. LoginUser 애노테이션 생성 및 LoginUserArgumentResolver과
AuthInterceptor 생성
=>  로그인 처리를 AuthInterceptor와 @LoginUser로 공통 처리
=>  개별 메서드나 클래스에서 여러 번 처리할 필요 없음
=>  로그인 토큰 헤더 없이 처리할 경로를 설정 (/auth, /faqs )

2.  DTO 수정 및 MyStoryController, ShareStoryController, LikeController 등에 
로그인 헤더에서 가져온 userId를 이용할 수 있도록 코드 수정